### PR TITLE
Avoid deprecated `java.net.URL` constructor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ lazy val root = (project in file("."))
     name := "sbt-dependency-check",
     startYear := Some(2025),
     homepage := Some(url("https://github.com/nMoncho/sbt-dependency-check")),
-    licenses := Seq("MIT License" -> new URL("http://opensource.org/licenses/MIT")),
+    licenses := Seq("MIT License" -> url("http://opensource.org/licenses/MIT")),
     headerLicense := Some(
       HeaderLicense.MIT("2025", "the original author or authors", HeaderLicenseStyle.SpdxSyntax)
     ),


### PR DESCRIPTION
- https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html#%3Cinit%3E(java.lang.String)
- https://bugs.openjdk.org/browse/JDK-8295949