### PR TITLE
Avoid old varargs splice syntax

### DIFF
--- a/src/sbt-test/sbt-dependency-check/aggregate-check/build.sbt
+++ b/src/sbt-test/sbt-dependency-check/aggregate-check/build.sbt
@@ -20,7 +20,7 @@ ThisBuild / dependencyCheckNvdApi := sys.env
 
 lazy val root = (project in file("."))
   .aggregate(core)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += "org.eclipse.jetty" % "jetty-runner" % "9.2.4.v20141103" % "provided",
     libraryDependencies += "commons-collections" % "commons-collections" % "3.2.1" % "optional",
@@ -66,7 +66,7 @@ lazy val root = (project in file("."))
   )
 
 lazy val util = (project in file("util"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies ++= Seq(
       "commons-beanutils"            % "commons-beanutils"   % "1.9.1"         % "test",
@@ -76,13 +76,13 @@ lazy val util = (project in file("util"))
 
 lazy val core = project
   .dependsOn(util)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += "org.apache.commons" % "commons-collections4" % "4.1"
   )
 
 lazy val ignore = (project in file("ignore"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.9"
   )

--- a/src/sbt-test/sbt-dependency-check/all-projects/build.sbt
+++ b/src/sbt-test/sbt-dependency-check/all-projects/build.sbt
@@ -18,7 +18,7 @@ lazy val commonSettings = Seq(
 
 lazy val root = (project in file("."))
   .aggregate(core)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     dependencyCheckFailBuildOnCVSS := 0,
     TaskKey[Unit]("check") := {
@@ -57,7 +57,7 @@ lazy val root = (project in file("."))
   )
 
 lazy val core = (project in file("core"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += "org.apache.commons" % "commons-collections4" % "4.1",
     dependencyCheckSuppressions := SuppressionSettings(
@@ -68,7 +68,7 @@ lazy val core = (project in file("core"))
   )
 
 lazy val inScope = (project in file("inScope"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.9",
     dependencyCheckSuppressions := SuppressionSettings(

--- a/src/sbt-test/sbt-dependency-check/list-settings/build.sbt
+++ b/src/sbt-test/sbt-dependency-check/list-settings/build.sbt
@@ -16,13 +16,13 @@ lazy val commonSettings = Seq(
 
 lazy val root = (project in file("."))
   .aggregate(core)
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     dependencyCheckFailBuildOnCVSS := 0
   )
 
 lazy val core = (project in file("core"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += "org.apache.commons" % "commons-collections4" % "4.1",
     dependencyCheckSuppressions := SuppressionSettings(
@@ -33,7 +33,7 @@ lazy val core = (project in file("core"))
   )
 
 lazy val inScope = (project in file("inScope"))
-  .settings(commonSettings: _*)
+  .settings(commonSettings)
   .settings(
     libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.9",
     dependencyCheckSuppressions := SuppressionSettings(


### PR DESCRIPTION
prepare for sbt 2.x build

https://docs.scala-lang.org/scala3/reference/changed-features/vararg-splices.html